### PR TITLE
feat: add internal-dependencies layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ By default, Spring Boot groups all dependencies into a single Docker layer. When
 
 This action includes an optional `internal-dependencies` layer. To use it, configure `bootJar` in your `build.gradle`:
 
+> **Note**
+>
+> Works on both Spring Boot 2.7.x and 3.3.x (Groovy DSL). The config is identical — only the jar extraction mode differs (`layertools` vs `tools`), which is handled by the Dockerfile.
+> The loader include pattern `org/springframework/boot/loader/**` matches both the 2.x package (`o.s.b.loader.JarLauncher`) and the 3.2+ package (`o.s.b.loader.launch.JarLauncher`).
+
 ```groovy
 bootJar {
     layered {

--- a/README.md
+++ b/README.md
@@ -191,6 +191,37 @@ Following inputs can be used as `step.with` keys
 }
 ```
 
+## Internal Dependencies Layer
+
+By default, Spring Boot groups all dependencies into a single Docker layer. When in-house libraries update frequently, the entire dependencies layer gets re-downloaded on every `docker pull` — even if 99% of the jars are unchanged.
+
+This action includes an optional `internal-dependencies` layer. To use it, configure `bootJar` in your `build.gradle`:
+
+```groovy
+bootJar {
+    layered {
+        application {
+            intoLayer("spring-boot-loader") {
+                include "org/springframework/boot/loader/**"
+            }
+            intoLayer("application")
+        }
+        dependencies {
+            intoLayer("internal-dependencies") {
+                include "com.example.mycompany:*"  // your in-house group
+            }
+            intoLayer("snapshot-dependencies") {
+                include "*:*:*SNAPSHOT"
+            }
+            intoLayer("dependencies")
+        }
+        layerOrder = ["dependencies", "spring-boot-loader", "internal-dependencies", "snapshot-dependencies", "application"]
+    }
+}
+```
+
+Services without this config are unaffected — the `internal-dependencies` layer will be empty (0B).
+
 ## Resources
 
 - [GitHub Action Environment variables](https://docs.github.com/en/actions/learn-github-actions/environment-variables)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,8 @@ FROM ${SPRING_BOOT_BAKE_BASE_IMAGE} AS layered-tools
 ARG SPRING_BOOT_BAKE_APPDIR
 ARG GRADLE_BUILD_ARTIFACT
 RUN --mount=type=bind,target=/src,rw \
-    java -Djarmode=tools -jar /src/build/libs/${GRADLE_BUILD_ARTIFACT} extract --layers --launcher --destination ${SPRING_BOOT_BAKE_APPDIR}
+    java -Djarmode=tools -jar /src/build/libs/${GRADLE_BUILD_ARTIFACT} extract --layers --launcher --destination ${SPRING_BOOT_BAKE_APPDIR} \
+    && mkdir -p ${SPRING_BOOT_BAKE_APPDIR}/internal-dependencies/
 
 # Extract Spring Boot application layers using jarmode=layertools
 # Note: the jarmode=layertools is being deprecated in favor of jarmode=tools
@@ -17,7 +18,8 @@ FROM ${SPRING_BOOT_BAKE_BASE_IMAGE} AS layered-layertools
 ARG SPRING_BOOT_BAKE_APPDIR
 ARG GRADLE_BUILD_ARTIFACT
 RUN --mount=type=bind,target=/src,rw \
-    java -Djarmode=layertools -jar /src/build/libs/${GRADLE_BUILD_ARTIFACT} extract --destination ${SPRING_BOOT_BAKE_APPDIR}
+    java -Djarmode=layertools -jar /src/build/libs/${GRADLE_BUILD_ARTIFACT} extract --destination ${SPRING_BOOT_BAKE_APPDIR} \
+    && mkdir -p ${SPRING_BOOT_BAKE_APPDIR}/internal-dependencies/
 
 # Intermediate layer to extract the layers using the specified jarmode
 FROM layered-${JARMODE} AS layered
@@ -31,6 +33,7 @@ ENV SPRING_BOOT_BAKE_APPDIR=${SPRING_BOOT_BAKE_APPDIR}
 WORKDIR ${SPRING_BOOT_BAKE_APPDIR}
 COPY --from=layered ${SPRING_BOOT_BAKE_APPDIR}/dependencies/ ${SPRING_BOOT_BAKE_APPDIR}
 COPY --from=layered ${SPRING_BOOT_BAKE_APPDIR}/spring-boot-loader/ ${SPRING_BOOT_BAKE_APPDIR}
+COPY --from=layered ${SPRING_BOOT_BAKE_APPDIR}/internal-dependencies/ ${SPRING_BOOT_BAKE_APPDIR}
 COPY --from=layered ${SPRING_BOOT_BAKE_APPDIR}/snapshot-dependencies/ ${SPRING_BOOT_BAKE_APPDIR}
 COPY --from=layered ${SPRING_BOOT_BAKE_APPDIR}/application/ ${SPRING_BOOT_BAKE_APPDIR}
 ADD --chmod=0755 https://raw.githubusercontent.com/spring-boot-actions/spring-boot-bake/v4/docker/java-entrypoint.sh /java-entrypoint.sh


### PR DESCRIPTION
## Summary
- Add optional `internal-dependencies` Docker layer for in-house libraries that change frequently
- Services opt-in via `bootJar { layered { ... } }` in `build.gradle` to route specific dependency groups to this layer
- `mkdir -p` fallback ensures backward compatibility — services without the config get an empty 0B layer

## Why
Spring Boot groups all dependencies into a single Docker layer. When in-house libraries (e.g. internal SDKs) update frequently, the entire dependencies layer (~149MB) gets a new digest, forcing full re-download on every `docker pull` — even though 99% of the jars are unchanged.

With this change, in-house lib updates only re-download the small `internal-dependencies` layer (~580KB) instead of the full `dependencies` layer.

## Usage
In `build.gradle`:
```groovy
bootJar {
    layered {
        application {
            intoLayer("spring-boot-loader") {
                include "org/springframework/boot/loader/**"
            }
            intoLayer("application")
        }
        dependencies {
            intoLayer("internal-dependencies") {
                include "com.example.mycompany:*"
            }
            intoLayer("snapshot-dependencies") {
                include "*:*:*SNAPSHOT"
            }
            intoLayer("dependencies")
        }
        layerOrder = ["dependencies", "spring-boot-loader", "internal-dependencies", "snapshot-dependencies", "application"]
    }
}
```

## Test plan
- [x] Tested with `bootJar` config — in house SDK correctly routed to `internal-dependencies` (580KB layer)
- [x] Tested without `bootJar` config — `mkdir -p` creates empty dir, COPY produces 0B layer, no breakage
- [x] Verified layer caching works across multiple builds with `rewrite-timestamp=true`